### PR TITLE
GitHub Actionsの自動レビュワーと自動アサインのロジック改善

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,11 +1,7 @@
 addReviewers: true
-
-
 addAssignees: author
-
-
+numberOfReviewers: 0
 reviewers:
   - Regulus0811
   - Z00One
-
-numberOfReviewers: 2
+runOnDraft: true

--- a/.github/workflows/auto-issue-assign.yml
+++ b/.github/workflows/auto-issue-assign.yml
@@ -12,6 +12,6 @@ jobs:
     - name: 'Auto-assign issue'
       uses: pozil/auto-assign-issue@v1
       with:
-          repo-token: ${{ secrets.OG_TOKEN }}
-          assignees: ${{ github.event.pull_request.user.login }}
+          repo-token: ${{ secrets.ADMIN_TOKEN }}
+          assignees: ${{ github.event.issue.user.login }}
           numOfAssignee: 1

--- a/.github/workflows/auto-member.yml
+++ b/.github/workflows/auto-member.yml
@@ -1,4 +1,4 @@
-name: 'Auto Assign'
+name: Auto Assign & Auto Reviewer
 on:
   pull_request_target:
     types: [opened, ready_for_review]


### PR DESCRIPTION
## 🔍 このPRで解決したい問題は何ですか？

GitHub Actionsの自動レビュワーと自動アサインの設定を改善し、PR作成時に自動的にAssigneesとReviewersが割り当てられるようにしたいです。

## ✨ このPRで主に変わったことは何ですか？

- `.github/workflows/auto-reviewer.yml`のファイル名を`.github/workflows/auto-member.yml`に変更しました。
- 自動レビュワー割り当ての設定ファイル`.github/auto_fe_reviewer.yml`の名前を`.github/auto_assign.yml`に変更し、設定を更新しました。
- 自動イシュー割り当てのワークフロー`.github/workflows/auto-assign.yml`の設定を更新しました。

## 🔖 主な変更点以外に追加で変更された部分はありますか？

なし

## 🙏🏻 Reviewerに特に見ていただきたい部分はありますか？

新しい設定の適用とGitHub Actionsの動作確認に注目してください。

## 🩺 このPRでテストや検証が必要な部分はありますか？

PRとイシューが作成された際の自動割り当ての動作を確認する必要があります。

## 📚 関連するIssueやドキュメントのリンク

#3 

## 🖥 作動する様子

> スクリーンショットや録画したビデオ、またはgifを追加して、Reviewerが変更点を理解するのに役立ててください。

## 📌 PRを行う際の注意点

* Reviewerはコードレビュー時に良いコードの方向性を示しますが、コード修正を強制することはありません。
* Reviewerは良いコードを見つけた場合、賞賛と励ましを惜しみません。
* レビューは特別なケースでない限り、Reviewerに指定された時点から3日以内に行ってください。
* コメント作成時にPrefixにP1、P2、P3を書いていただくと、Assigneeがより明確にコメントに対して対応することができます。
  * P1 : 必ず反映してください (Request Changes) - 問題が発生したり、脆弱性が発見されたケースなど。
  * P2 : 反映を積極的に検討していただければと思います (コメント)。
  * P3 : こんな方法もあるんじゃないかな～などの些細な意見です (Chore)。
# 

---
## 📝 AssigneeのためのCheckList
- [x] Github Actionsが動作するか