### PR TITLE
GoogleAuthCallbackの変更

### DIFF
--- a/constants/http_status_codes.go
+++ b/constants/http_status_codes.go
@@ -26,4 +26,9 @@ const (
 	StatusBadGateway          = 502 // Bad Gateway
 	StatusServiceUnavailable  = 503 // Service Unavailable
 	StatusGatewayTimeout      = 504 // Gateway Timeout
+
+	/*
+		リダイレクト ステータスコード
+	*/
+	StatusFound = 302 // Status Found
 )

--- a/controllers/google_auth_controller.go
+++ b/controllers/google_auth_controller.go
@@ -102,5 +102,5 @@ func (controller *GoogleAuthController) GoogleAuthCallback(c *gin.Context) {
 		Path:     "/",
 	})
 
-	c.Redirect(http.StatusFound, "http://localhost:3000/")
+	c.Redirect(constants.StatusFound, "http://localhost:3000/")
 }

--- a/controllers/google_auth_controller.go
+++ b/controllers/google_auth_controller.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"encoding/json"
+	"net/http"
+	"time"
 
 	"github.com/YJU-OKURA/project_minori-gin-deployment-repo/constants"
 	"github.com/YJU-OKURA/project_minori-gin-deployment-repo/dto"
@@ -84,6 +86,21 @@ func (controller *GoogleAuthController) GoogleAuthCallback(c *gin.Context) {
 		return
 	}
 
-	finalRedirectURL := "http://localhost:3000/"
-	c.JSON(constants.StatusOK, gin.H{"token": token, "refresh_token": refreshToken, "user": user, "redirect_url": finalRedirectURL})
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     "access_token",
+		Value:    token,
+		Expires:  time.Now().Add(24 * time.Hour),
+		HttpOnly: true,
+		Path:     "/",
+	})
+
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     "refresh_token",
+		Value:    refreshToken,
+		Expires:  time.Now().Add(7 * 24 * time.Hour),
+		HttpOnly: true,
+		Path:     "/",
+	})
+
+	c.Redirect(http.StatusFound, "http://localhost:3000/")
 }


### PR DESCRIPTION
## 🔍 このPRで解決したい問題は何ですか？

- ログイン後のGoogleAuthCallback関数の処理方法を変更しました。以前はユーザー情報をJSON形式でフロントエンドに送信していましたが、セキュリティ向上のために、情報をクッキーに保存するようにロジックを変更しました。これにより、ユーザー情報の安全な扱いと、フロントエンドとバックエンド間の情報の安全なやり取りが可能になります。
なお、バックエンドコーディングスタイルに従うためにリダイレクト ステータスコードを追加しました。

## ✨ このPRで主に変わったことは何ですか？

* ログイン後のユーザー情報の扱い方を変更しました。具体的には、JSON形式での情報送信から、クッキーを使用した情報の保存・送信へと変更しました。

## 🔖 主な変更点以外に追加で変更された部分はありますか？

* なし

## 🙏🏻 Reviewerに特に見ていただきたい部分はありますか？

* 新しいクッキー保存のロジックについて、セキュリティ上の懸念がないか、特に確認していただきたいです。

## 🩺 このPRでテストや検証が必要な部分はありますか？

* 新しい認証フローがすべてのブラウザで正常に動作するかどうかの確認が必要です。
* セキュリティテストを行い、クッキーを介した情報のやり取りが安全であることを確認する必要があります。

## 📚 関連するIssueやTrello、ドキュメント

- #99 

## 🖥 作動する様子

この変更に関するスクリーンショットやビデオは現時点ではありません。テストが完了次第、追加される予定です。

## 📌 PRを行う際の注意点

* セキュリティに関する変更であるため、コードレビューは特に慎重に行ってください。
* レビューは可能な限り早く行っていただき、必要な場合はフィードバックをお願いします。
