### PR TITLE
[MIN-300] GetClass メソッドでクラスコードとシークレット情報をレスポンスに追加

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1536,13 +1536,14 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "成功時、クラスの情報を返します",
+                        "description": "クラスの情報を返します。クラスコードとシークレットが存在する場合、それらも含まれます。",
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "400": {
-                        "description": "error: リクエストが不正です",
+                        "description": "error: リクエストが不正です (詳細なエラーメッセージを含む)",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -1556,7 +1557,7 @@ const docTemplate = `{
                         }
                     },
                     "500": {
-                        "description": "error: サーバーエラーが発生しました",
+                        "description": "error: サーバーエラーが発生しました (詳細なエラーメッセージを含む)",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1525,13 +1525,14 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "成功時、クラスの情報を返します",
+                        "description": "クラスの情報を返します。クラスコードとシークレットが存在する場合、それらも含まれます。",
                         "schema": {
-                            "$ref": "#/definitions/models.Class"
+                            "type": "object",
+                            "additionalProperties": true
                         }
                     },
                     "400": {
-                        "description": "error: リクエストが不正です",
+                        "description": "error: リクエストが不正です (詳細なエラーメッセージを含む)",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -1545,7 +1546,7 @@
                         }
                     },
                     "500": {
-                        "description": "error: サーバーエラーが発生しました",
+                        "description": "error: サーバーエラーが発生しました (詳細なエラーメッセージを含む)",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1114,11 +1114,12 @@ paths:
       - application/json
       responses:
         "200":
-          description: 成功時、クラスの情報を返します
+          description: クラスの情報を返します。クラスコードとシークレットが存在する場合、それらも含まれます。
           schema:
-            $ref: '#/definitions/models.Class'
+            additionalProperties: true
+            type: object
         "400":
-          description: 'error: リクエストが不正です'
+          description: 'error: リクエストが不正です (詳細なエラーメッセージを含む)'
           schema:
             additionalProperties: true
             type: object
@@ -1128,7 +1129,7 @@ paths:
             additionalProperties: true
             type: object
         "500":
-          description: 'error: サーバーエラーが発生しました'
+          description: 'error: サーバーエラーが発生しました (詳細なエラーメッセージを含む)'
           schema:
             additionalProperties: true
             type: object

--- a/repositories/class_code_repository.go
+++ b/repositories/class_code_repository.go
@@ -43,6 +43,10 @@ func (r *classCodeRepository) FindByCode(code string) (*models.ClassCode, error)
 func (r *classCodeRepository) FindByClassID(cid uint) (*models.ClassCode, error) {
 	var classCode models.ClassCode
 	result := r.db.Where("cid = ?", cid).First(&classCode)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+
 	if result.Error != nil {
 		return nil, result.Error
 	}


### PR DESCRIPTION
## 🔍 このPRで解決したい問題は何ですか？

* このPRでは、`GetClass` メソッドを拡張し、クラス情報に加えて関連する`クラスコード（code）`と`シークレット（secret）`をレスポンスに含めるようにします。これにより、クライアントはクラス情報と共にクラスコードとシークレットも取得できるようになります。
この変更の背景として、クライアント側でクラスコードとシークレットを使用する要件が発生しました。これをサポートするために、サーバーサイドのレスポンスにこれらの情報を追加する必要がありました。

## ✨ このPRで主に変わったことは何ですか？

* `class_code_repository.go` において、`FindByClassID` メソッドを改良し、指定されたクラスIDに対してクラスコードが見つからなかった場合に nil を返すように変更しました。
* `class_controller.go` の `GetClass` メソッドを拡張し、`クラスコード (code)` と`シークレット (secret)` が存在する場合、これらの情報をレスポンスに追加しました。
* Swagger API ドキュメント（godoc コメント）を更新し、レスポンス形式の変更を反映させました。

## 🔖 主な変更点以外に追加で変更された部分はありますか？

* なし

## 🙏🏻 Reviewerに特に見ていただきたい部分はありますか？

* `class_code_repository.go` のエラーハンドリングが適切に行われているかどうかを確認してください。
* `class_controller.go` の `GetClass` メソッドのレスポンス拡張が正しく実装されているかどうか、特にクラスコードとシークレットが含まれる場合の処理が適切かどうかを見てください。

## 🩺 このPRでテストや検証が必要な部分はありますか？

* クラス情報の取得に関する単体テストを更新し、新しいレスポンス形式（クラスコードとシークレットの追加）に対応するようにしました。
* テストケースとして、クラスコードとシークレットが存在する場合と存在しない場合の両方をカバーしています。

## 📚 関連するIssueやJira、ドキュメント

* #304 
* [클래스 정보 조회 시에 클래스 코드, 비밀번호도 함께 조회하도록 수정(クラス情報照会時にクラスコード、パスワードも一緒に照会するように修正)](https://okura-minori.atlassian.net/jira/core/projects/MIN/board?selectedIssue=MIN-300)

## 🖥 作動する様子

> スクリーンショットや録画したビデオ、またはgifを追加して、Reviewerが変更点を理解するのに役立ててください。

## 📌 PRを行う際の注意点

* Reviewerはコードレビュー時に良いコードの方向性を示しますが、コード修正を強制することはありません。
* Reviewerは良いコードを見つけた場合、賞賛と励ましを惜しみません。
* レビューは特別なケースでない限り、Reviewerに指定された時点から3日以内に行ってください。
* コメント作成時にPrefixにP1、P2、P3を書いていただくと、Assigneeがより明確にコメントに対して対応することができます。
  * P1 : 必ず反映してください (Request Changes) - 問題が発生したり、脆弱性が発見されたケースなど。
  * P2 : 反映を積極的に検討していただければと思います (コメント)。
  * P3 : こんな方法もあるんじゃないかな～などの些細な意見です (Chore)。