### PR TITLE
[MIN-301] 出席データのエラーハンドリング改善および複数追加のサポート

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,60 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/at": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "複数の出席情報を作成または更新します。'Attendance', 'Tardy', 'Absence'のいずれかのステータスを持つことができます。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Attendance"
+                ],
+                "summary": "複数の出席情報を作成または更新",
+                "parameters": [
+                    {
+                        "description": "出席情報",
+                        "name": "attendances",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/controllers.AttendanceInput"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "作成または更新に成功しました",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "無効なリクエスト",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "サーバーエラーが発生しました",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/at/attendance/{id}": {
             "get": {
                 "security": [
@@ -49,6 +103,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/models.Attendance"
                         }
                     },
+                    "400": {
+                        "description": "無効なリクエスト",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "サーバーエラーが発生しました",
                         "schema": {
@@ -81,20 +141,6 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Class ID",
-                        "name": "cid",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "uid",
-                        "in": "query",
-                        "required": true
                     }
                 ],
                 "responses": {
@@ -104,66 +150,8 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
-                    "500": {
-                        "description": "サーバーエラーが発生しました",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/at/{cid}/{uid}/{csid}": {
-            "post": {
-                "security": [
-                    {
-                        "Bearer": []
-                    }
-                ],
-                "description": "出席情報を作成または更新",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Attendance"
-                ],
-                "summary": "出席情報を作成または更新",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Class ID",
-                        "name": "cid",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "uid",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Class Schedule ID",
-                        "name": "csid",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Status",
-                        "name": "status",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "作成または更新に成功しました",
+                    "400": {
+                        "description": "無効なリクエスト",
                         "schema": {
                             "type": "string"
                         }
@@ -212,6 +200,12 @@ const docTemplate = `{
                             "items": {
                                 "$ref": "#/definitions/models.Attendance"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "無効なリクエスト",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     "500": {
@@ -2964,6 +2958,23 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "controllers.AttendanceInput": {
+            "type": "object",
+            "properties": {
+                "cid": {
+                    "type": "integer"
+                },
+                "csid": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "integer"
+                }
+            }
+        },
         "controllers.UpdateUserNameRequest": {
             "type": "object",
             "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,6 +4,60 @@
         "contact": {}
     },
     "paths": {
+        "/at": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "複数の出席情報を作成または更新します。'Attendance', 'Tardy', 'Absence'のいずれかのステータスを持つことができます。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Attendance"
+                ],
+                "summary": "複数の出席情報を作成または更新",
+                "parameters": [
+                    {
+                        "description": "出席情報",
+                        "name": "attendances",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/controllers.AttendanceInput"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "作成または更新に成功しました",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "無効なリクエスト",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "サーバーエラーが発生しました",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/at/attendance/{id}": {
             "get": {
                 "security": [
@@ -38,6 +92,12 @@
                             "$ref": "#/definitions/models.Attendance"
                         }
                     },
+                    "400": {
+                        "description": "無効なリクエスト",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "サーバーエラーが発生しました",
                         "schema": {
@@ -70,20 +130,6 @@
                         "name": "id",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Class ID",
-                        "name": "cid",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "uid",
-                        "in": "query",
-                        "required": true
                     }
                 ],
                 "responses": {
@@ -93,66 +139,8 @@
                             "type": "string"
                         }
                     },
-                    "500": {
-                        "description": "サーバーエラーが発生しました",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/at/{cid}/{uid}/{csid}": {
-            "post": {
-                "security": [
-                    {
-                        "Bearer": []
-                    }
-                ],
-                "description": "出席情報を作成または更新",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Attendance"
-                ],
-                "summary": "出席情報を作成または更新",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Class ID",
-                        "name": "cid",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "uid",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Class Schedule ID",
-                        "name": "csid",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Status",
-                        "name": "status",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "作成または更新に成功しました",
+                    "400": {
+                        "description": "無効なリクエスト",
                         "schema": {
                             "type": "string"
                         }
@@ -201,6 +189,12 @@
                             "items": {
                                 "$ref": "#/definitions/models.Attendance"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "無効なリクエスト",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     "500": {
@@ -2953,6 +2947,23 @@
         }
     },
     "definitions": {
+        "controllers.AttendanceInput": {
+            "type": "object",
+            "properties": {
+                "cid": {
+                    "type": "integer"
+                },
+                "csid": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "integer"
+                }
+            }
+        },
         "controllers.UpdateUserNameRequest": {
             "type": "object",
             "properties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,15 @@
 definitions:
+  controllers.AttendanceInput:
+    properties:
+      cid:
+        type: integer
+      csid:
+        type: integer
+      status:
+        type: string
+      uid:
+        type: integer
+    type: object
   controllers.UpdateUserNameRequest:
     properties:
       new_name:
@@ -188,37 +199,29 @@ definitions:
 info:
   contact: {}
 paths:
-  /at/{cid}/{uid}/{csid}:
+  /at:
     post:
       consumes:
       - application/json
-      description: 出席情報を作成または更新
+      description: 複数の出席情報を作成または更新します。'Attendance', 'Tardy', 'Absence'のいずれかのステータスを持つことができます。
       parameters:
-      - description: Class ID
-        in: path
-        name: cid
+      - description: 出席情報
+        in: body
+        name: attendances
         required: true
-        type: integer
-      - description: User ID
-        in: path
-        name: uid
-        required: true
-        type: integer
-      - description: Class Schedule ID
-        in: path
-        name: csid
-        required: true
-        type: integer
-      - description: Status
-        in: query
-        name: status
-        required: true
-        type: string
+        schema:
+          items:
+            $ref: '#/definitions/controllers.AttendanceInput'
+          type: array
       produces:
       - application/json
       responses:
         "200":
           description: 作成または更新に成功しました
+          schema:
+            type: string
+        "400":
+          description: 無効なリクエスト
           schema:
             type: string
         "500":
@@ -227,7 +230,7 @@ paths:
             type: string
       security:
       - Bearer: []
-      summary: 出席情報を作成または更新
+      summary: 複数の出席情報を作成または更新
       tags:
       - Attendance
   /at/{classID}:
@@ -250,6 +253,10 @@ paths:
             items:
               $ref: '#/definitions/models.Attendance'
             type: array
+        "400":
+          description: 無効なリクエスト
+          schema:
+            type: string
         "500":
           description: サーバーエラーが発生しました
           schema:
@@ -270,21 +277,15 @@ paths:
         name: id
         required: true
         type: integer
-      - description: Class ID
-        in: query
-        name: cid
-        required: true
-        type: integer
-      - description: User ID
-        in: query
-        name: uid
-        required: true
-        type: integer
       produces:
       - application/json
       responses:
         "200":
           description: 削除に成功しました
+          schema:
+            type: string
+        "400":
+          description: 無効なリクエスト
           schema:
             type: string
         "500":
@@ -313,6 +314,10 @@ paths:
           description: Attendance
           schema:
             $ref: '#/definitions/models.Attendance'
+        "400":
+          description: 無効なリクエスト
+          schema:
+            type: string
         "500":
           description: サーバーエラーが発生しました
           schema:

--- a/services/attendance_service.go
+++ b/services/attendance_service.go
@@ -56,7 +56,14 @@ func (s *attendanceService) GetAllAttendancesByCID(cid uint) ([]models.Attendanc
 
 // GetAttendanceByID IDによって出席情報を取得
 func (s *attendanceService) GetAttendanceByID(id string) (*models.Attendance, error) {
-	return s.repo.GetAttendanceByID(id)
+	attendance, err := s.repo.GetAttendanceByID(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return attendance, nil
 }
 
 // DeleteAttendance 出席情報を削除


### PR DESCRIPTION
## 🔍 このPRで解決したい問題は何ですか？

このPRは、以下の2つの主要な改善を実施します：
1. 出席データの取得時に、データが存在しない場合に適切なエラーハンドリングを行い、「not found」ステータスを返すようにします。
2. 出席データを追加または更新する際に、複数の出席情報を一度に処理できるようにします。

これにより、APIのユーザビリティが向上し、開発者が出席データを効果的に管理するための柔軟性が高まります。

## ✨ このPRで主に変わったことは何ですか？

- `CreateOrUpdateAttendance` メソッドを更新し、複数の出席情報を一度に追加または更新できるようにしました。
- `GetAttendance` メソッドを改善し、出席データが見つからない場合に「not found」ステータスを返すようにしました。
- リクエストパラメータのバリデーションを強化し、無効なパラメータが渡された場合のエラーハンドリングを改善しました。

## 🔖 主な変更点以外に追加で変更された部分はありますか？

- `CreateOrUpdateAttendance` メソッドにおいて、`Status` フィールドが 'Attendance', 'Tardy', または 'Absence' であることを確認するバリデーションを追加しました。
- Swagger ドキュメントを更新し、複数の出席情報を処理する新しいエンドポイント仕様を反映させました。

## 🙏🏻 Reviewerに特に見ていただきたい部分はありますか？

- バルク操作（複数の出席情報を一度に追加または更新）の実装方法が適切であるかどうか。
- エラーハンドリングの改善が、期待通りに機能しているかどうか。
- リクエストパラメータのバリデーションが、十分かつ効果的であるかどうか。

## 🩺 このPRでテストや検証が必要な部分はありますか？

- 複数の出席情報を一度に追加または更新するAPIリクエストが正しく処理されるかのテスト。
- 出席データが存在しない場合に、正しく「not found」ステータスが返されるかの検証。
- リクエストパラメータが無効な場合に、適切なエラーが返されるかの確認。

## 📚 関連するIssueやJira、ドキュメント

* #325
* [출석 API 개선(出席APIの改善)](https://okura-minori.atlassian.net/jira/core/projects/MIN/board?selectedIssue=MIN-301)

## 🖥 作動する様子

> スクリーンショットや録画したビデオ、またはgifを追加して、Reviewerが変更点を理解するのに役立ててください。

## 📌 PRを行う際の注意点

* Reviewerはコードレビュー時に良いコードの方向性を示しますが、コード修正を強制することはありません。
* Reviewerは良いコードを見つけた場合、賞賛と励ましを惜しみません。
* レビューは特別なケースでない限り、Reviewerに指定された時点から3日以内に行ってください。
* コメント作成時にPrefixにP1、P2、P3を書いていただくと、Assigneeがより明確にコメントに対して対応することができます。
  * P1 : 必ず反映してください (Request Changes) - 問題が発生したり、脆弱性が発見されたケースなど。
  * P2 : 反映を積極的に検討していただければと思います (コメント)。
  * P3 : こんな方法もあるんじゃないかな～などの些細な意見です (Chore)。